### PR TITLE
remote server 배포를 위한 http 설정

### DIFF
--- a/Procfile
+++ b/Procfile
@@ -1,0 +1,1 @@
+web: python last-guardian.py

--- a/README.md
+++ b/README.md
@@ -44,13 +44,33 @@ Google Routes API는 "막차 시간"을 직접 제공하지 않습니다. 대신
 
 ## 설치 방법
 
-### 1. 의존성 설치
+### 옵션 A: Railway 클라우드 배포 (추천)
 
-```bash
-pip install fastmcp requests python-dotenv
+#### 1. Railway 프로젝트 생성
+1. [Railway](https://railway.app/)에 가입
+2. "New Project" → "Deploy from GitHub repo" 선택
+3. 이 저장소 연결
+
+#### 2. 환경 변수 설정
+Railway 대시보드에서 **Environment Variables** 추가:
+```
+GOOGLE_API_KEY=your_google_api_key_here
 ```
 
-### 2. 환경 변수 설정
+#### 3. 자동 배포 완료!
+- Railway가 자동으로 빌드 & 배포
+- 공개 URL 생성됨 (예: `https://lastguardian-production-xxxx.up.railway.app`)
+- 이 URL을 PlayMCP에 등록하면 끝!
+
+### 옵션 B: 로컬 실행 (Claude Desktop)
+
+#### 1. 의존성 설치
+
+```bash
+pip install -r requirements.txt
+```
+
+#### 2. 환경 변수 설정
 
 `.env` 파일 생성:
 
@@ -60,7 +80,7 @@ GOOGLE_API_KEY=your_google_api_key_here
 
 > Google Cloud Console에서 Routes API를 활성화하고 API 키를 발급받으세요.
 
-### 3. Claude Desktop 설정
+#### 3. Claude Desktop 설정
 
 `claude_desktop_config.json`에 추가:
 

--- a/last-guardian.py
+++ b/last-guardian.py
@@ -351,4 +351,9 @@ def analyze_escape_plan(origin: str, destination: str) -> str:
 
 
 if __name__ == "__main__":
-    mcp.run()
+    # Railway 배포를 위한 HTTP 서버 모드
+    import uvicorn
+    import os
+
+    port = int(os.getenv("PORT", 8000))
+    uvicorn.run(mcp.get_asgi_app(), host="0.0.0.0", port=port)

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,4 @@
+fastmcp
+requests
+python-dotenv
+uvicorn


### PR DESCRIPTION
왜 http로 구동해야하는가?
->STDIO: 터미널 입출력으로 통신함 클라우드 환경에서는 외부와 소통할 방법 X
지금까지 써왔던 방식으로는 로컬에서 통신하는 방법으로 하였지만 카카오 PlayMCP에 등록하기 위해선 remote server 방식을 제공해야하기 때문에 http 방식으로 구현해야함
stateless하게 구현하지 않으면 서버를 scaling하기 어렵고 여러 사용자의 connection을 유지해야하기 때문에 서버 부담이 높아짐
